### PR TITLE
composition/proposal: Expand on interface-type API

### DIFF
--- a/composition/proposal.md
+++ b/composition/proposal.md
@@ -611,23 +611,19 @@ class sdf::InterfaceModel {
   ///   If this name contains "::", an error will be raised.
   /// \param[in] reposture_function Called after pose graphs are constructed to
   ///   reposture objects.
-  /// \param[in] canonical_link The canonical link. If nullptr, this will be set
-  ///   to the first registered link. If non-empty, this will be registered
-  ///   using `AddLink`.
-  /// \param[in] model_frame The model frame. If specified, this must be named
-  ///   "__model__". If nullptr, this will resolve to the canonical_link,
-  ///   and a new frame "__model__" will be registered by libsdformat when
-  ///   incorporating the model into the frame graph.
+  /// \param[in] canonical_link_name The canonical link's name. (It must be
+  ///   registered).
+  /// \param[in] X_LcM Model frame pose relative to canonical link's frame.
   public: InterfaceModel(
       std::string name,
-      RepostureFunction reposture_function,
-      sdf::InterfaceLink canonical_link = {},
-      sdf::InterfaceFrame model_frame = {});
+      sdf::RepostureFunction reposture_function,
+      std::string canonical_link_name,
+      math::Pose3d X_LcM);
   /// Accessors.
   public: std::string GetName() const;
   public: sdf::RepostureFunction GetRepostureFunction() const;
-  public: sdf::InterfaceLink GetCanonicalLink() const;
-  public: sdf::InterfaceFrame GetModelFrame() const;
+  public: std::string GetCanonicalLinkName() const;
+  public: math::Pose3d GetModelFramePoseInCanonicalLinkFrame() const;
   /// Provided so that hierarchy can still be leveraged from SDFormat.
   public: void AddNestedModel(sdf::InterfaceModelPtr nested_model);
   /// Gets registered nested models.

--- a/composition/proposal.md
+++ b/composition/proposal.md
@@ -581,6 +581,7 @@ class sdf:::InterfaceFrame {
 
 class sdf::InterfaceModel {
   /// \param[in] name The *local* name (no nesting, e.g. "::").
+  ///   If this name contains "::", an error will be raised.
   /// \param[in] canonical_link_frame The "grounding frame" for the canonical
   ///   link. If nullptr, this will be set to the first registered
   ///   grounding frame. If not nullptr, this will be registered using
@@ -591,8 +592,8 @@ class sdf::InterfaceModel {
   ///   incorporating the model into the frame graph.
   public: InterfaceModel(
       std::string name,
-      sdf::InterfaceFramePtr model_frame = nullptr,
-      sdf::InterfaceFramePtr canonical_link_frame = nullptr);
+      sdf::InterfaceFramePtr canonical_link_frame = nullptr,
+      sdf::InterfaceFramePtr model_frame = nullptr);
   /// Accessors.
   public: std::string GetName() const;
   public: sdf::InterfaceFrameConstPtr GetCanonicalLinkFrame() const;
@@ -635,6 +636,9 @@ class sdf::InterfaceModel {
 ///     continue testing out other custom parsers registered under the same
 ///     extension (e.g. a parser for `.yaml`, which may cover many different
 ///     schemas).
+///
+/// If an exception is raised by this callback, libsdformat will *not* try to
+///intercept the exception.
 using sdf::CustomModelParser = std::function<
     sdf::InterfaceModelPtr (sdf::NestedInclude include, Errors& errors)>;
 

--- a/composition/proposal.md
+++ b/composition/proposal.md
@@ -1160,7 +1160,9 @@ There are seven phases for validating the kinematics data in a world:
         and the [SemanticPose::Resolve](https://github.com/osrf/sdformat/blob/sdformat9_9.2.0/include/sdf/SemanticPose.hh#L65-L73)
         function.
 
-Short form:
+#### Short-form modifications for Interface API
+
+*TODO(eric.cousineau): Factor into above steps.*
 
 * Load the SDFormat model DOM.
 * For each include:

--- a/composition/proposal.md
+++ b/composition/proposal.md
@@ -645,7 +645,7 @@ class sdf::InterfaceModel {
   /// Provided so that the including SDFormat model can still interface with
   /// the declared links.
   public: void AddLink(sdf::InterfaceLink link);
-  /// Gets registered frames.
+  /// Gets registered links.
   public: std::vector<sdf::InterfaceLink> GetLinks() const;
 };
 

--- a/composition/proposal.md
+++ b/composition/proposal.md
@@ -542,12 +542,6 @@ be registered in `libsdformat`. This is described in the following pseudocode,
 along with a specification of the proposed contract for custom parsers:
 
 ~~~c++
-class sdf::InterfacePose {
-  /// \param[in] pose
-  /// \param[in] relative_to
-  public: InterfacePose(Pose3d pose, std::string relative_to);
-};
-
 // This can be used in both //model elements as well as /world.
 struct sdf::NestedInclude {
   /// Provides the URI as specified in `//include/uri`. This may or may not end
@@ -578,29 +572,33 @@ struct sdf::NestedInclude {
 
 class sdf:::InterfaceFrame {
   /// \param[in] name The *local* name.
-  /// \param[in] pose The pose of the frame.
-  public: InterfaceFrame(std::string name, sdf::InterfacePose pose);
+  /// \param[in] attached_to Name of attached-to frame. Must be "__model__" if
+  ///   attached to model.
+  /// \param[in] X_AF The pose of the frame relative to attached frame.
+  public: InterfaceFrame(
+      std::string name, std::string attached_to, math::Pose3d X_AF);
   /// Accessors.
   public: std::string GetName() const;
-  public: sdf::InterfacePose GetPose() const;
+  public: std::string GetAttachedTo() const;
+  public: math::Pose3d GetPoseInAttachedToFrame() const;
 };
 
 class sdf::InterfaceLink {
   /// \param[in] name The *local* name.
-  /// \param[in] pose The pose of the link.
-  public: InterfaceLink(std::string name, sdf::InterfacePose pose);
+  /// \param[in] pose The pose of the link relative to model frame.
+  public: InterfaceLink(std::string name, math::Pose3d X_ML);
   /// Accessors.
   public: std::string GetName() const;
-  public: sdf::InterfacePose GetPose() const;
+  public: math::Pose3d GetPoseInModelFrame() const;
 };
 
 class sdf::NestedModelFramePoseGraph {
   /// \param[in] Minimum API to posture the model frame.
   public: math::Pose3d ResolveNestedModelFramePoseInWorldFrame() const;
   /// \param[in] relative_to Can be "world", or any frame within the nested
-  ///   model's frame graph. (It cannot reach out).
+  ///   model's frame graph. (It cannot reach outside of this model).
   public: math::Pose3d ResolveNestedFramePose(
-      std::string frame_name, std::string relative_to);
+      std::string frame_name, std::string relative_to = "world");
 };
 
 // Repostures custom models for the given nested custom model.

--- a/composition/proposal.md
+++ b/composition/proposal.md
@@ -548,6 +548,7 @@ class sdf::InterfacePose {
   public: InterfacePose(Pose3d pose, std::string relative_to);
 };
 
+// This can be used in both //model elements as well as /world.
 struct sdf::NestedInclude {
   /// Provides the URI as specified in `//include/uri`. This may or may not end
   /// with a file extension if it refers to a model directory.

--- a/composition/proposal.md
+++ b/composition/proposal.md
@@ -616,17 +616,23 @@ class sdf::InterfaceModel {
   ///   reposture objects.
   /// \param[in] canonical_link_name The canonical link's name. (It must be
   ///   registered).
-  /// \param[in] X_LcM Model frame pose relative to canonical link's frame.
+  /// \param[in] model_frame_pose_in_canonical_link_frame Model frame pose
+  ///   relative to canonical link's frame. Defaults to identity.
+  /// \param[in] model_frame_pose_in_parent_model_frame Model frame pose
+  ///   relative to the including model's frame. Defaults to identity.
+  ///   \note This will not be used if //include/pose is specified.
   public: InterfaceModel(
       std::string name,
       sdf::RepostureFunction reposture_function,
       std::string canonical_link_name,
-      math::Pose3d X_LcM);
+      math::Pose3d model_frame_pose_in_canonical_link_frame = {},
+      math::Pose3d model_frame_pose_in_parent_model_frame = {});
   /// Accessors.
   public: std::string GetName() const;
   public: sdf::RepostureFunction GetRepostureFunction() const;
   public: std::string GetCanonicalLinkName() const;
   public: math::Pose3d GetModelFramePoseInCanonicalLinkFrame() const;
+  public: math::Pose3d GetModelFramePoseInParentModelFrame() const;
   /// Provided so that hierarchy can still be leveraged from SDFormat.
   public: void AddNestedModel(sdf::InterfaceModelPtr nested_model);
   /// Gets registered nested models.

--- a/composition/proposal.md
+++ b/composition/proposal.md
@@ -545,11 +545,14 @@ along with a specification of the proposed contract for custom parsers:
 // This can be used in both //model elements as well as /world.
 struct sdf::NestedInclude {
   /// Provides the URI as specified in `//include/uri`. This may or may not end
-  /// with a file extension if it refers to a model directory.
+  /// with a file extension (it will not end an extension if it refers to a
+  /// model package).
   std::string uri;
 
-  /// Provides the *resolved* file name from the uri. This should generally be
-  /// used for predicates on filenames.
+  /// Provides the *resolved* absolute file path from the URI.
+  /// It is recommended to use this in `CustomModelParser` when check
+  /// predicates on filenames -- however, the predicates should generally only
+  /// check the file extension.
   std::string resolved_file_name;
 
   // N.B. Should be unnecesssary if downstream consumer has composition. Not

--- a/composition/proposal.md
+++ b/composition/proposal.md
@@ -540,6 +540,23 @@ In order to do so, it is proposed that the following API hook be permitted to
 be registered in `libsdformat`:
 
 ~~~c++
+struct sdf::NestedInclude {
+  // Resolved or not resolved?
+  // ERIC: My money is on unresolved.
+  std::string file_path;
+
+  // Name of the model in absolute hierarhcy.
+  // N.B. Should be unnecesssary if downstream consumer has composition. Not
+  // the case for Drake :(
+  std::string absolute_model_name;
+
+  // Name relative to immediate parent.
+  std::string local_model_name;
+
+  // Pose of how the model is postured.
+  sdf::SemanticPose pose;
+};
+
 /// \param[out] errors Errors encountered during custom parsing.
 /// \returns An optional ModelInterface. If this returns a nullopt, then it
 /// means libsdformat should continue testing out other custom parsers
@@ -552,7 +569,7 @@ using CustomModelParser =
 
 // \param[in] extension Extension to parse, including dot. e.g. `.yaml`.
 // \param[in] model_parser Callback as described by CustomModelParser.
-void registerCustomModelParser(
+void sdf::Root::registerCustomModelParser(
     std::string extension,
     CustomModelParser model_parser);
 

--- a/composition/proposal.md
+++ b/composition/proposal.md
@@ -503,7 +503,7 @@ models, and `model://` URIs for Gazebo models.
 
 ##### 1.4.6 `//include/static`
 
-**TODO(eric)**: Reconsider this in future iterations of the proposal.
+**TODO(eric.cousineau)**: Reconsider this in future iterations of the proposal.
 
 This allows the `//model/static` element to be overridden and will affect
 *all* models transitively included via the `//include` element, and can *only*

--- a/composition/proposal.md
+++ b/composition/proposal.md
@@ -620,7 +620,7 @@ class sdf::InterfaceModel {
 /// The latest parser gains precedence.
 ///
 /// Custom model parsers are *never* checked if resolved file extension ends
-/// with `*.sdf`.
+/// with `*.sdf` or `*.world`.
 /// If libsdformat encounters a `*.urdf` file, it will first check custom
 /// parser. If no custom parser is found, it will then convert the URDF XML to
 /// SDFormat XML, and parse it as an SDFormat file.
@@ -664,16 +664,28 @@ top-level model's `//pose` definitions.
 
 **Alternatives Considered**:
 
-* Explicitly use a `sdf::FileNamePredicate` when calling
-`registerCustomModelParser`. This was not done because there is sufficient
-functionality in the API for individual parsers to do this.
-* Rather than use `sdf::FileNamePredicate`, it was considered to use something
-like `sdf::FileContentsPredicate`, to allow for a MIME type-like check to
-happen. However, since this is explicitly for models that are being included by
-`//include/uri`, it is expected that the URI supplied to SDFormat will resolve
-to a file on disk, thus we do not need to worry about contents "over the wire"
-(e.g. models passed from a Gazebo client to a Gazebo server,
-`/robot_description` in ROS, etc.).
+* For handling file predicates based on name and/or content:
+  * Explicitly use a `sdf::FileNamePredicate` when calling
+  `registerCustomModelParser`. This was not done because there is sufficient
+  functionality in the API for individual parsers to do this.
+  * Rather than use `sdf::FileNamePredicate`, it was considered to use something
+  like `sdf::FileContentsPredicate`, to allow for a MIME type-like check to
+  happen. However, since this is explicitly for models that are being included by
+  `//include/uri`, it is expected that the URI supplied to SDFormat will resolve
+  to a file on disk, thus we do not need to worry about contents "over the wire"
+  (e.g. models passed from a Gazebo client to a Gazebo server,
+  `/robot_description` in ROS, etc.).
+
+* For the composition API:
+  * It was considered to expose as much of the toplogy as possible, both links
+  and frames, and possibly joints. However, that would complicate the
+  implementation:
+    * Ths `libsdformat` API would somehow have to infect existing API to allow
+      custom-included models to popluate existing graphs explicitly.
+    * This infection would require additional encapsulation of `libsdformat`
+      details (e.g. XML pointser for elements). While not necessarily bad in
+      principle, this may be an impractical rearchitecture for the next
+      release.
 
 #### 1.6 Proposed Parsing Stages
 

--- a/composition/proposal.md
+++ b/composition/proposal.md
@@ -687,6 +687,30 @@ top-level model's `//pose` definitions.
       principle, this may be an impractical rearchitecture for the next
       release.
 
+##### 1.5.1 Modifications to existing `libsdformat` API
+
+To support the above interface, `sdf::SemanticPose` should be able to
+indicate `::ResolveAttachedToBody()`:
+
+This functionality should migrate from `Frame::ResolveAttachedToBody()`, and
+the `Frame::` method should be deprecated, wher
+`Frame::SemanticPose().ResolveAttachedToBody()` should be used instead.
+
+Additionally, the *scope* of the returned frame should be specified.
+
+Currently, the assumption is that any `attached_to` frame should be in or under
+the current model's scope, so it may be necessary for the `SemanticPose` class
+to either (a) know which scope it was specified in or (b) always return the
+absolute-scoped name, and rely on downstream consumers to get the relative
+path.
+
+**Alternatives Considered**:
+
+* Instead of infecting `sdf::SemanticPose`, instead this API should simply
+  dictate its own `attached_to` frame (via `sdf::InterfaceFrame`). This means
+  that downstream code must be responsible for obtaining this `attached_to`
+  frame.
+
 #### 1.6 Proposed Parsing Stages
 
 **TODO(eric.cousineau)**: Add this in a follow-up PR.

--- a/composition/proposal.md
+++ b/composition/proposal.md
@@ -329,7 +329,8 @@ are more local.
 **Alternatives Considered for Reference Syntax**
 
 * Use `/` instead of `::`, and permit `../` for upwards references.
-    * This looks a bit more like a filesystem (more relevant to these semantics). However, there is inertia due to Gazebo's usage of `::`
+    * This looks a bit more like a filesystem (more relevant to these
+    semantics). However, there is inertia due to Gazebo's usage of `::`
     for composition, in both SDFormat files and for models (and IPC channels /
     topics in general).
 * Upwards references:
@@ -537,83 +538,138 @@ downstream libraries to permit specifying non-SDFormat model via `//include`
 tags *without* `libsdformat` having to try and convert the model to SDFormat.
 
 In order to do so, it is proposed that the following API hook be permitted to
-be registered in `libsdformat`:
+be registered in `libsdformat`. This is described in the following pseudocode,
+along with a specification of the proposed contract for custom parsers:
 
 ~~~c++
 struct sdf::NestedInclude {
-  /// Provides the *unresolved* file path as provided from the file directly
-  /// included.
-  std::string file_path;
+  /// Provides the URI as specified in `//include/uri`. This may or may not end
+  /// with a file extension if it refers to a model directory.
+  std::string uri;
 
-  /// Name of the model in absolute hierarchy.
-  /// Example: `top_model::middle_model::my_new_model`
+  /// Provides the *resolved* file name from the uri. This should generally be
+  /// used for predicates on filenames.
+  std::string resolved_file_name;
+
   // N.B. Should be unnecesssary if downstream consumer has composition. Not
   // the case for Drake :(
+  /// Name of the model in absolute hierarchy.
+  /// Example: `top_model::middle_model::my_new_model`
   std::string absolute_model_name;
 
-  /// Name relative to immediate parent.
+  /// Name relative to immediate parent as specified in `//include/@name`.
   /// Example: `my_new_model`
   std::string local_model_name;
 
-  /// Pose information from //include/pose.
+  /// Pose information from `//include/pose`.
   sdf::SemanticPose pose;
-};
-
-class sdf::InterfaceModel {
-  /// \param[in] name The *local* name (no nesting, e.g. "::").
-  public: InterfaceModel(std::string name);
-  /// Provided so that hierarchy can still be leveraged from SDFormat.
-  public: void AddNestedModel(sdf::InterfaceModelPtr nested_model);
-  /// Provided so that the including SDFormat model can still interface with
-  /// the declared frames.
-  public: void AddFrame(sdf::InterfaceFramePtr frame);
 };
 
 class sdf:::InterfaceFrame {
   /// \param[in] name The *local* name.
   /// \param[in] pose The semantic pose of the frame.
-  ///   If the parent frame is specified as "", then the frame itself is
-  ///   considered as a link, and can be used in `attached_to` to denote an
-  ///   anchoring in the frame graph.
+  ///   If the attached_to frame is specified as "", then this will be a
+  ///   "grounding frame": it will be considered as a link in libsdformat's
+  ///   constructed frame graph.
   public: InterfaceFrame(std::string name, sdf::SemanticPosePtr pose);
+  /// Accessors.
+  public: std::string GetName() const;
+  public: sdf::SemanticPosePtr GetSemanticPose() const;
+  /// Determinse if this is a grounding frame.
+  public: bool IsGroundingFrame() const;
 };
 
-/// \param[in] include The //include tag information from which this model
+class sdf::InterfaceModel {
+  /// \param[in] name The *local* name (no nesting, e.g. "::").
+  /// \param[in] canonical_link_frame The "grounding frame" for the canonical
+  ///   link. If nullptr, this will be set to the first registered
+  ///   grounding frame. If not nullptr, this will be registered using
+  ///   `AddFrame`.
+  /// \param[in] model_frame The model frame. If specified, this must be named
+  ///   "__model__". If nullptr, this will resolve to the canonical_link_frame,
+  ///   and a new frame "__model__" will be registered by libsdformat when
+  ///   incorporating the model into the frame graph.
+  public: InterfaceModel(
+      std::string name,
+      sdf::InterfaceFramePtr model_frame = nullptr,
+      sdf::InterfaceFramePtr canonical_link_frame = nullptr);
+  /// Accessors.
+  public: std::string GetName() const;
+  public: sdf::InterfaceFrameConstPtr GetCanonicalLinkFrame() const;
+  public: sdf::InterfaceFrameConstPtr GetModelFrame() const;
+  /// Provided so that hierarchy can still be leveraged from SDFormat.
+  public: void AddNestedModel(sdf::InterfaceModelPtr nested_model);
+  /// Gets registered nested models.
+  public: std::vector<sdf::InterfaceModelConstPtr> GetNestedModels() const;
+  /// Provided so that the including SDFormat model can still interface with
+  /// the declared frames.
+  public: void AddFrame(sdf::InterfaceFramePtr frame);
+  /// Gets registered frames.
+  public: std::vector<sdf::InterfaceFrameConstPtr> GetFrames() const;
+};
+
+/// Defines a custom model parser.
+///
+/// Every custom model parser should define it's own way of (quickly) 
+/// determining if it should parse a model. This should generally be done by
+/// looking at the file extension of `include.resolved_file_name`, and
+/// returning nullptr if it doesn't match a given criteria.
+///
+/// Custom model parsers are visited in the *reverse* of how they are defined.
+/// The latest parser gains precedence.
+///
+/// Custom model parsers are *never* checked if resolved file extension ends
+/// with `*.sdf`.
+/// If libsdformat encounters a `*.urdf` file, it will first check custom
+/// parser. If no custom parser is found, it will then convert the URDF XML to
+/// SDFormat XML, and parse it as an SDFormat file.
+///
+/// \param[in] include The parsed //include information from which this model
 ///   should be parsed.
 /// \param[out] errors Errors encountered during custom parsing.
+///   If any errors are reported, this must return nullptr.
 /// \returns An optional ModelInterface.
-///   * If not nullptr, hte returned model interface is incorprated into the
+///   * If not nullptr, the returned model interface is incorporated into the
 ///     existing model and its frames are exposed through the frame graph.
-///   * If nullptr, then libsdformat should continue testing out other custom
-///     parsers registered under the same extension (e.g. a parser for
-///     `.yaml`, which may cover many different schemas).
+///   * If nullptr and no errors are reported, then libsdformat should
+///     continue testing out other custom parsers registered under the same
+///     extension (e.g. a parser for `.yaml`, which may cover many different
+///     schemas).
 using sdf::CustomModelParser = std::function<
     sdf::InterfaceModelPtr (sdf::NestedInclude include, Errors& errors)>;
 
-using sdf::StringPredicate = std::function<bool (const std::string)>;
-
-// \param[in] file_check Predicate for files. If true, it will attempt to parse.
-//   Registered custom parsers do *not* need to be mutually exclusive. Rather,
-//   they are attempted in order.
-// \param[in] model_parser Callback as described above.
+/// Registers a custom model parser.
+/// \param[in] model_parser Callback as described above.
 void sdf::Root::registerCustomModelParser(
-    sdf::StringPredicate file_check,
     sdf::CustomModelParser model_parser);
-
 ~~~
 
-In addition to this, the following update to hierarchies are suggested to be
-made:
+When `libsdformat` calls a custom model parser and that model parser succeeds,
+then the parsing code will:
 
-~~~c++
-class Model : private InterfaceModel {  // ... ???
-  // Use private inheritance to hide mutation methods.
-};
+1. First ensure no `errors` were specified.
+2. Incorporate the resulting `sdf::InterfaceModelPtr interface`:
+  a. Assert that it is not `nullptr`
+  b. For each `interface.GetNestedModels()`:
+    i. Recursively incorporate the nested models.
+  c. Register model frame and canonical link in frame graph.
+  d. Register each individual frame in frame graph.
 
-class Link : private InterfaceLink { ... };
+That should then allow the included models to have their frames used in the
+top-level model's `//pose` definitions.
 
-class Frame : private InterfaceFrame { ... };
-~~~
+**Alternatives Considered**:
+
+* Explicitly use a `sdf::FileNamePredicate` when calling
+`registerCustomModelParser`. This was not done because there is sufficient
+functionality in the API for individual parsers to do this.
+* Rather than use `sdf::FileNamePredicate`, it was considered to use something
+like `sdf::FileContentsPredicate`, to allow for a MIME type-like check to
+happen. However, since this is explicitly for models that are being included by
+`//include/uri`, it is expected that the URI supplied to SDFormat will resolve
+to a file on disk, thus we do not need to worry about contents "over the wire"
+(e.g. models passed from a Gazebo client to a Gazebo server,
+`/robot_description` in ROS, etc.).
 
 #### 1.6 Proposed Parsing Stages
 

--- a/composition/proposal.md
+++ b/composition/proposal.md
@@ -732,6 +732,15 @@ API.
   Additionally, there is complication with what scope the semantic pose should
   supply the frame in.
 
+##### 1.5.2 Motivating Example
+
+In order to inform this API, a (non-working) prototype usage of the (phantom)
+API was hashed out in
+[drake#13128](https://github.com/robotlocomotion/drake/pull/13128).
+
+**TODO(eric.cousineau)**: Update this once the initial API is fleshed out and
+Drake has a working prototype usage.
+
 #### 1.6 Proposed Parsing Stages
 
 The following sections describe the phases for parsing the kinematics of an

--- a/composition/proposal.md
+++ b/composition/proposal.md
@@ -637,7 +637,7 @@ class sdf::InterfaceModel {
   /// the declared links.
   public: void AddLink(sdf::InterfaceLink link);
   /// Gets registered frames.
-  public: std::vector<sdf::InterfaceLink> GetFrames() const;
+  public: std::vector<sdf::InterfaceLink> GetLinks() const;
 };
 
 /// Defines a custom model parser.
@@ -728,7 +728,7 @@ API.
 * There was consideration to have `sdf::SemanticPose` be able to declare
   indicate `::ResolveAttachedToFrame()`; however, this was not chosen because
   it requires being able to construct a `sdf::SemanticPose` in isolation and
-  ultimately has more information than is necessary for this ineterface.
+  ultimately has more information than is necessary for this interface.
   Additionally, there is complication with what scope the semantic pose should
   supply the frame in.
 

--- a/composition/proposal.md
+++ b/composition/proposal.md
@@ -572,8 +572,12 @@ struct sdf::NestedInclude {
   /// the "world" frame.
   math::Pose3d pose_WM;
 
-  //// As defined by `//include/static`.
+  /// As defined by `//include/static`.
   bool is_static{false};
+
+  /// This is a "virtual" XML element that will contain all custom (*unparsed*)
+  /// elements and attributes within `//include`.
+  sdf::ElementPtr virtual_custom_elements;
 };
 
 class sdf:::InterfaceFrame {


### PR DESCRIPTION
For more background, see existing proposal:
https://github.com/osrf/sdf_tutorials/blob/251b28804a6e79ac1b89001b8fd0036bc07e0d7d/composition/proposal.md

Basically, this interface API is to allow included models to either (a) be parsed by `libsdformat` (and thus must be completely understood) or (b) be parsed by the downstream library, with the absolute minimum information passed back to `libsdformat` for links and frames (for posturing and connecting joints).

Motivational WIP usage of phantom API:
https://github.com/RobotLocomotion/drake/pull/13128

(Branch ported from BitBucket)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/osrf/sdf_tutorials/3)
<!-- Reviewable:end -->
