### PR TITLE
Migrate bitbucket links to GitHub

### DIFF
--- a/composition/legacy_behavior.md
+++ b/composition/legacy_behavior.md
@@ -110,14 +110,14 @@ location of the model and optionally override some of its properties:
   with the included model.
 
 In `libsdformat`, the contents of the `<uri>` element are passed to the
-[sdf::findFile](https://bitbucket.org/osrf/sdformat/src/1a3f95acdc3cd86ab99713f85ddb2c54226c4de9/src/SDF.cc#lines-58:167)
+[sdf::findFile](https://github.com/osrf/sdformat/blob/sdformat9_9.0.0/src/SDF.cc#L58-L167)
 function defined in
-[sdf/SDFImpl.hh](https://bitbucket.org/osrf/sdformat/src/1a3f95acdc3cd86ab99713f85ddb2c54226c4de9/include/sdf/SDFImpl.hh#lines-55:65).
+[sdf/SDFImpl.hh](https://github.com/osrf/sdformat/blob/sdformat9_9.0.0/include/sdf/SDFImpl.hh#L55-L65).
 This function searches for the model files using the steps in the following
 order until the model is found:
 
   1. Users can define paths on their system associated with a specific URI
-     scheme using [sdf::addURIPath](https://bitbucket.org/osrf/sdformat/src/1a3f95acdc3cd86ab99713f85ddb2c54226c4de9/include/sdf/SDFImpl.hh#lines-67:72).
+     scheme using [sdf::addURIPath](https://github.com/osrf/sdformat/blob/sdformat9_9.0.0/include/sdf/SDFImpl.hh#L67-L72).
      For example, if `sdf::addURIPath("model://", path);` has been called,
      including a `<uri>model://sphere</uri>` will search the folder in `path`
      for subfolders named `sphere`.
@@ -226,7 +226,7 @@ The result of processing `ParentModel` results in the following model
 </model>
 ```
 
-> **Note** Due to a [bug in libsdformat](https://bitbucket.org/osrf/sdformat/issues/219),
+> **Note** Due to a [bug in libsdformat](https://github.com/osrf/sdformat/issues/219),
 the `xyz` vector of joint axes in
 nested models is always interpreted to be expressed in the model frame
 regardless of the value of the `<use_parent_model_frame>` element.
@@ -372,10 +372,10 @@ example.
 
 <!--# References-->
 
-<!--[] https://bitbucket.org/osrf/gazebo_design/pull-requests/18/add-support-for-nested-models-in-gazebo/-->
+<!--[] https://osrf-migration.github.io/osrf-others-gh-pages/#!/osrf/gazebo_design/pull-requests/18-->
 
 <!--[] http://gazebosim.org/tutorials?tut=nested_model&cat=build_robot-->
 
 <!--[] http://gazebosim.org/tutorials?tut=model_structure&cat=build_robot-->
 
-<!--[] https://bitbucket.org/osrf/sdformat/pull-requests/214/support-nesting-of-model-sdf-elements/diff-->
+<!--[] https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/214-->

--- a/custom_elements_attributes/proposal.md
+++ b/custom_elements_attributes/proposal.md
@@ -10,7 +10,7 @@ Addisu Taddese `<addisu@openrobotics.org>`
 
 SDFormat aims to be a specification for describing simulations without being
 closely coupled with specific simulators such as Gazebo. It is also a goal of
-this project to provide [libsdformat](https://bitbucket/osrf/sdformat) as the
+this project to provide [libsdformat](https://github.com/osrf/sdformat) as the
 canonical library for parsing SDFormat files. As SDFormat gets more widely used
 by other applications, it is natural for developers of those applications to
 want to extend SDFormat beyond the latest standard to specify parameters for

--- a/install/tutorial_2-0.md
+++ b/install/tutorial_2-0.md
@@ -26,12 +26,12 @@ Install prerequisites.  A clean Ubuntu system will need:
 
         mkdir ~/sdf_source
         cd ~/sdf_source/
-        hg clone https://bitbucket.org/osrf/sdformat
+        git clone https://github.com/osrf/sdformat
 
 1. Change directory into the sdformat repository and switch to the 2.0 branch
 
         cd sdformat
-        hg up sdf_2.0
+        git checkout sdf_2.0
 
    **Note: the <tt>default</tt> branch is the development branch where you'll find the bleeding edge code, your cloned repository should be on this branch by default but we recommend you switch to the 2.0 branch if you desire more stability**
 

--- a/install/tutorial_6-x.md
+++ b/install/tutorial_6-x.md
@@ -59,12 +59,12 @@ shell scripts for setting the necessary environment variables.
 
         mkdir ~/sdf_source
         cd ~/sdf_source/
-        hg clone https://bitbucket.org/osrf/sdformat
+        git clone https://github.com/osrf/sdformat
 
 1. Change directory into the sdformat repository and switch to the sdf6 branch
 
         cd sdformat
-        hg up sdf6
+        git checkout sdf6
 
    **Note: the <tt>default</tt> branch is the development branch where you'll find the bleeding edge code, your cloned repository should be on this branch by default but we recommend you switch to the sdf6 branch if you desire more stability**
 

--- a/manifest.xml
+++ b/manifest.xml
@@ -189,7 +189,7 @@
 
         Use the *Edit* button in the upper right corner of a tutorial page to
         go directly to its source at
-        [bitbucket.org/osrf/sdf_tutorials](https://bitbucket.org/osrf/sdf_tutorials).
+        [github.com/osrf/sdf_tutorials](https://github.com/osrf/sdf_tutorials).
       </description>
       <tutorials>
         <tutorial>specify_pose</tutorial>

--- a/pose_frame_semantics/proposal.md
+++ b/pose_frame_semantics/proposal.md
@@ -220,7 +220,7 @@ The SDFormat 1.4 specification does not clearly state to which link the model
 frame is attached, but Gazebo has a convention of choosing the first `//link`
 element listed as a child of a `//model` as the `@attached_to` link and
 referring to this as the model's Canonical Link
-(see [Model.cc from gazebo 10.1.0](https://bitbucket.org/osrf/gazebo/src/gazebo10_10.1.0/gazebo/physics/Model.cc#lines-130:132)).
+(see [Model.cc from gazebo 10.1.0](https://github.com/osrf/gazebo/blob/gazebo10_10.1.0/gazebo/physics/Model.cc#L130-L132)).
 
 In SDFormat 1.5, a model without links is considered valid, but its implicit
 frame is not well-defined since it is not clear where the frame is attached.
@@ -1392,7 +1392,7 @@ Each API returns an error code if errors are found during parsing.
     data complies with the [schema](http://sdformat.org/schemas/root.xsd).
     Schema `.xsd` files are generated from the `.sdf` specification files
     when building `libsdformat` with the
-    [xmlschema.rb script](https://bitbucket.org/osrf/sdformat/src/sdformat6_6.2.0/tools/xmlschema.rb).
+    [xmlschema.rb script](https://github.com/osrf/sdformat/blob/sdformat6_6.2.0/tools/xmlschema.rb).
 
 2.  **Name attribute checking:**
     Check that name attributes are not an empty string `""`,
@@ -1530,7 +1530,7 @@ There are *seven* phases for validating the kinematics data in a world:
     data complies with the [schema](http://sdformat.org/schemas/root.xsd).
     Schema `.xsd` files are generated from the `.sdf` specification files
     when building `libsdformat` with the
-    [xmlschema.rb script](https://bitbucket.org/osrf/sdformat/src/sdformat6_6.2.0/tools/xmlschema.rb).
+    [xmlschema.rb script](https://github.com/osrf/sdformat/blob/sdformat6_6.2.0/tools/xmlschema.rb).
 
 2.  **Name attribute checking:**
     Check that name attributes are not an empty string `""`,

--- a/pose_frame_semantics/tutorial.md
+++ b/pose_frame_semantics/tutorial.md
@@ -494,7 +494,7 @@ This section has discussed naming conventions for `<joint>` elements as
 children of a `<model>`.
 For completeness, it should be noted that the SDF specification allows for a
 `<joint>` to be a direct child of a `<world>`
-(see [world.sdf:58](https://bitbucket.org/osrf/sdformat/src/21d2cbe52bb/sdf/1.4/world.sdf#world.sdf-58)),
+(see [world.sdf:32](https://github.com/osrf/sdformat/blob/sdformat9_9.0.0/sdf/1.4/world.sdf#L32)),
 but the naming conventions for this case are not established, as this use case
 is not supported by Gazebo or any other known software.
 
@@ -580,7 +580,7 @@ Each API returns an error code if errors are found during parsing.
     data complies with the [schema](http://sdformat.org/schemas/root.xsd).
     Schema `.xsd` files are generated from the `.sdf` specification files
     when building `libsdformat` with the
-    [xmlschema.rb script](https://bitbucket.org/osrf/sdformat/src/sdformat6_6.2.0/tools/xmlschema.rb).
+    [xmlschema.rb script](https://github.com/osrf/sdformat/blob/sdformat6_6.2.0/tools/xmlschema.rb).
 
 2.  **Name attribute checking:**
     Check that name attributes are not an empty string `""`, and that sibling
@@ -630,7 +630,7 @@ These three phases are listed below:
     data complies with the [schema](http://sdformat.org/schemas/root.xsd).
     Schema `.xsd` files are generated from the `.sdf` specification files
     when building `libsdformat` with the
-    [xmlschema.rb script](https://bitbucket.org/osrf/sdformat/src/sdformat6_6.2.0/tools/xmlschema.rb).
+    [xmlschema.rb script](https://github.com/osrf/sdformat/blob/sdformat6_6.2.0/tools/xmlschema.rb).
 
 2.  **Name attribute checking:**
     Check that name attributes are not an empty string `""`, and that sibling

--- a/specify_pose/tutorial.md
+++ b/specify_pose/tutorial.md
@@ -64,13 +64,13 @@ which both share the same definition of roll, pitch, and yaw angles:
 
 For a command-line utility to convert between roll-pitch-yaw angles,
 quaternions, and rotation matrices, please see the
-[quaternion\_from\_euler](https://bitbucket.org/ignitionrobotics/ign-math/src/ign-math4/examples/quaternion_from_euler.cc)
-and [quaternion\_to\_euler](https://bitbucket.org/ignitionrobotics/ign-math/src/ign-math4/examples/quaternion_to_euler.cc)
+[quaternion\_from\_euler](https://github.com/ignitionrobotics/ign-math/blob/ign-math4/examples/quaternion_from_euler.cc)
+and [quaternion\_to\_euler](https://github.com/ignitionrobotics/ign-math/blob/ign-math4/examples/quaternion_to_euler.cc)
 example programs in ignition math.
 
 Software implementations for converting between this Euler angle convention and
 quaternions can be found in
-[ignition::math::Quaternion](https://bitbucket.org/ignitionrobotics/ign-math/src/ignition-math4_4.0.0/include/ignition/math/Quaternion.hh#Quaternion.hh-308:398)
+[ignition::math::Quaternion](https://github.com/ignitionrobotics/ign-math/blob/ignition-math4_4.0.0/include/ignition/math/Quaternion.hh#L308-L398)
 C++ class, and the [urdf::Rotation](https://github.com/ros/urdfdom_headers/blob/1.0.3/urdf_model/include/urdf_model/pose.h#L103-L155) C++ class.
 
 Some other implementations:


### PR DESCRIPTION
Preview: http://sdformat.org/tutorials?branch=update_bitbucket_links

Most of these links are directly "ported" to GitHub, but I noticed that a reference to world.sdf in `pose_frame_semantics/tutorial.md` had an incorrect line number, so I corrected it.