### PR TITLE
HTML comment rendering in t.o.c.

### DIFF
--- a/developers/proposal_format.md
+++ b/developers/proposal_format.md
@@ -25,7 +25,7 @@ should be replaced or removed.
 
 <!--
 TODO(eric): Add a link to root README to show how to preview a branch once
-#2 is fixed.
+issue 2 is fixed.
 -->
 
 ---


### PR DESCRIPTION
I think the `#` inside the comment tags on line 28 is actually breaking up the comment, and for some reason the line ends up in the table of contents side bar:

![image](https://user-images.githubusercontent.com/52295207/82393123-6d216400-99fa-11ea-807d-39ea5b85135d.png)
