### PR TITLE
composition: Add section for up-converting unflattened models

### DIFF
--- a/composition/legacy_behavior.md
+++ b/composition/legacy_behavior.md
@@ -187,7 +187,7 @@ the name of the nested model followed by `::` is prepended to the names of
 these links and joints. The following example shows how this works. Consider
 the following model named `ChildModel` and its parent model `ParentModel`:
 
-```
+```xml
 <model name="ChildModel">
   <link name="L1">
     <pose>0 1 0 0 0 0</pose>
@@ -207,7 +207,7 @@ the following model named `ChildModel` and its parent model `ParentModel`:
 </model>
 ```
 
-```
+```xml
 <model name="ParentModel">
   <include>
     <uri>/path/to/ChildModel</uri>
@@ -218,7 +218,7 @@ the following model named `ChildModel` and its parent model `ParentModel`:
 
 The result of processing `ParentModel` results in the following model
 
-```
+```xml
 <model name="ParentModel">
   <link name="ChildModel::L1">
     <pose>1 1 1 0 0 0</pose> <!-- Note the modified pose -->
@@ -230,7 +230,9 @@ The result of processing `ParentModel` results in the following model
       </geometry>
     </visual>
   </link>
-  <link name="ChildModel::L2"/>
+  <link name="ChildModel::L2">
+    <pose>1 0 1 0 0 0</pose>
+  </link>
   <joint name="ChildModel::J1">
     <parent>ChildModel::L1</parent>
     <child>ChildModel::L2</child>

--- a/composition/legacy_behavior.md
+++ b/composition/legacy_behavior.md
@@ -200,7 +200,7 @@ the following model named `ChildModel` and its parent model `ParentModel`:
     </visual>
   </link>
   <link name="L2"/>
-  <joint name="J1">
+  <joint name="J1" type="revolute">
     <parent>L1</parent>
     <child>L2</child>
   </joint>
@@ -216,19 +216,17 @@ the following model named `ChildModel` and its parent model `ParentModel`:
 </model>
 ```
 
-The result of processing `ParentModel` results in the following model
+The result of processing `ParentModel` results in the following model (as of
+`libsdformat 9.2`):
 
 ```xml
 <model name="ParentModel">
   <frame name="ChildModel::__model__" attached_to="ChildModel::L1">
-    <!--
-    N.B. This frame is only added as of libsdformat 9.2,  BitBucket PR #668
-    -->
-    <pose/>
+    <pose relative_to="__model__">1 0 1 0 0 0</pose>
   </frame>
   <link name="ChildModel::L1">
-    <pose>1 1 1 0 0 0</pose> <!-- Note the modified pose -->
-    <visual name="v1"> <!-- Names of child elements of link are not modified -->
+    <pose relative_to="ChildModel::__model__">0 1 0 0 0 0</pose>
+    <visual name="v1">
       <geometry>
         <sphere>
           <radius>0.1</radius>
@@ -237,9 +235,9 @@ The result of processing `ParentModel` results in the following model
     </visual>
   </link>
   <link name="ChildModel::L2">
-    <pose>1 0 1 0 0 0</pose>
+    <pose relative_to="ChildModel::__model__">0 0 0 0 0 0</pose>
   </link>
-  <joint name="ChildModel::J1">
+  <joint name="ChildModel::J1" type="revolute">
     <parent>ChildModel::L1</parent>
     <child>ChildModel::L2</child>
   </joint>
@@ -251,6 +249,8 @@ the `xyz` vector of joint axes in
 nested models is always interpreted to be expressed in the model frame
 regardless of the value of the `<use_parent_model_frame>` element.
 
+> **Note**: Before `libsdformat 9.2`, the flattened model had poses merged
+together and did not leverage the nested model's frame.
 
 ## Characteristics of nested models 
 

--- a/composition/legacy_behavior.md
+++ b/composition/legacy_behavior.md
@@ -220,6 +220,12 @@ The result of processing `ParentModel` results in the following model
 
 ```xml
 <model name="ParentModel">
+  <frame name="ChildModel::__model__" attached_to="ChildModel::L1">
+    <!--
+    N.B. This frame is only added as of libsdformat 9.2,  BitBucket PR #668
+    -->
+    <pose/>
+  </frame>
   <link name="ChildModel::L1">
     <pose>1 1 1 0 0 0</pose> <!-- Note the modified pose -->
     <visual name="v1"> <!-- Names of child elements of link are not modified -->

--- a/composition/proposal.md
+++ b/composition/proposal.md
@@ -80,9 +80,11 @@ For including models, it is nice to have access to other model types, e.g.
 including a custom model specified as a `*.yaml` or connecting to some other
 legacy format. Generally, the interface between models only really needs access
 to explicit and implicit frames (for welding joints, attaching sensors, etc.).
-The present implementation of `//include` requires that SDFormat know
-*everything* about the included model, whereas a user could instead provide an
-adapter to provide the minimal information necessary for assembly.
+The present implementation of `//include` (present
+[since `libsdformat4`](https://github.com/osrf/sdformat/blob/sdformat4_4.0.0/src/parser.cc#L738))
+requires that SDFormat know *everything* about the included model, whereas a
+user could instead provide an adapter to provide the minimal information
+necessary for assembly.
 
 There are existing solutions to handle composition. Generally, those
 solutions are some form of text / XML generation (e.g. `xacro`, or Python /
@@ -711,7 +713,7 @@ handle "partially" flattened models.
 * Nested models with an explicitly specified `__model__` frame (e.g.
 `ChildModel::__model__`) will have this frame removed, and this will be
 converted to the appropriate `//model/pose`. If `@attached_to` is specified to
-something other than this nexted model's first link, then
+something other than this nested model's first link, then
 `//model/@canonical_link` will also be updated.
   * Any poses within this model will be expected to either refer to this model
   frame, or any frame contained by this model, s.t. no numerical computation
@@ -729,9 +731,11 @@ even with up-conversion:
 <sdf version="1.7">
   <model name="anything">
     <link name="M1::B"/>
-    <link name="M2::B">
-      <pose relative_to="M1::B"/>  <!-- INVALID: This attribute does not start with `M2::`. -->
-    </link>
+    <joint name="M1::J">
+      <parent>M1::B</parent>
+      <child>M2::B</child>  <!-- INVALID: This reference does not start with `M1::`. -->
+    </joint>
+    <link name="M2::B"/>
   </model>
 </sdf>
 ~~~

--- a/composition/proposal.md
+++ b/composition/proposal.md
@@ -581,6 +581,7 @@ when a new model should be created and when the nested names (e.g.
 `M1::my_link`) should be "unnested" (e.g. `my_link` in model `M1`).
 
 To illustrate, the following model from the Legacy Behavior documentation:
+
 ~~~xml
 <sdf version="1.5">
   <model name="ParentModel">
@@ -602,7 +603,9 @@ To illustrate, the following model from the Legacy Behavior documentation:
   </model>
 </sdf>
 ~~~
+
 should be (naively) up-converted to:
+
 ~~~xml
 <sdf version="1.5*">
   <model name="ParentModel">
@@ -673,6 +676,7 @@ the newly created `//model/pose`.
 
 This could have been valid in SDFormat 1.7, but is not valid in SDFormat 1.8,
 even with up-coversion:
+
 ~~~xml
 <sdf version="1.7">
   <link name="M1::B"/>

--- a/composition/proposal.md
+++ b/composition/proposal.md
@@ -57,10 +57,13 @@ swapping out grippers).
 
 As of SDFormat 1.7, nesting a model with a `//model/include` tag has different
 behavior than direct nesting with `//model/model`,
-part of the reason being that nesting directly with `//model/model` is not yet
-implemented in the current `libsdformat` (9.1.0). Nesting of models generally
-implies that the elements can be referenced via a form of scope, such as
-`{scope}::{name}`. However, `::` is not a special token and thus can be
+part of the reason being that nesting directly with `//model/model` was not
+implemented in the `libsdformat` until 9.3.0. As mentioned in the
+[Legacy Behavior](/tutorials?tut=composition&ver=1.5&#libsdformats-implementation-of-include-in-models) documentation, `//include` works by effectively flattening the model; when this happens, certain details may "leak" through.
+
+Normall, nesting of models generally implies that the elements can be
+referenced via a form of scope, such as `{scope}::{name}`.
+However, `::` is not a special token and thus can be
 used to create "false" hierarchy or potential name collisions. Additionally, there is
 no way for elements within the same file to refer "up" to another element, e.g. with in a robot assembly, adding a weld between a gripper and an arm when the
 two are sibiling models.
@@ -558,6 +561,126 @@ kinematic loops (e.g. adding a rope, and attaching both ends to the world).
 **Note**: `//joint/child == "world"` is forbidden solely due to encapsulation
 issues with poses, as described in the
 [Pose Frame Semantics proposal](/tutorials?tut=pose_frame_semantics_proposal#1-2-explicit-vs-implicit-frames).
+
+##### 1.4.7 Up-Converting Flattened Models
+
+As mentioned in the Motivation, in SDFormat <= 1.7 (`libsdformat` <= 10)
+`//include` was implemented by "flattening" the model. This means that when
+`libsdformat` parses a model which has nested `//include` models, the resultant
+XML will be *invalid* for SDFormat 1.8 because the model would be using the
+reserved `::` delimiter in an invalid fashion (to define a link, joint, etc.).
+
+This would not be an issue if this flattened XML were a transient artifact
+(e.g. temporary serialization for communicating models from a Gazebo server to
+a client). However, users could have converted their models with `ign sdf`, and
+thus there would be "data at rest" in this format.
+
+To work around this, the conversion from SDFormat 1.7 to 1.8 should have an
+"unflattening" phase which takes the flattened XML and *naively* tries to infer
+when a new model should be created and when the nested names (e.g.
+`M1::my_link`) should be "unnested" (e.g. `my_link` in model `M1`).
+
+To illustrate, the following model from the Legacy Behavior documentation:
+~~~xml
+<sdf version="1.5">
+  <model name="ParentModel">
+    <link name="ChildModel::L1">
+      <pose>1 1 1 0 0 0</pose>
+      <visual name="v1">-->
+        <geometry>
+          <sphere>
+            <radius>0.1</radius>
+          </sphere>
+        </geometry>
+      </visual>
+    </link>
+    <link name="ChildModel::L2"/>
+    <joint name="ChildModel::J1">
+      <parent>ChildModel::L1</parent>
+      <child>ChildModel::L2</child>
+    </joint>
+  </model>
+</sdf>
+~~~
+should be (naively) up-converted to:
+~~~xml
+<sdf version="1.5*">
+  <model name="ParentModel">
+    <model name="ChildModel">
+      <link name="L1">
+        <pose>1 1 1 0 0 0</pose>
+        <visual name="v1">-->
+          <geometry>
+            <sphere>
+              <radius>0.1</radius>
+            </sphere>
+          </geometry>
+        </visual>
+      </link>
+      <link name="L2"/>
+      <joint name="J1">
+        <parent>L1</parent>
+        <child>L2</child>
+      </joint>
+    </model>
+  </model>
+</sdf>
+~~~
+
+The following basic rules will apply:
+
+* Models will be inferred (implicitly created) by parsing the following
+attributes:
+  * `//frame/@name`
+  * `//joint/@name`
+  * `//link/@name`
+  * `//model/@name`.
+* When a new model is created, all new elements under this model will have the
+following attributes "unnested" by stripping the (required) prefix of
+`"{model_name}::"`:
+  * `//frame/@attached_to`
+  * `//frame/@attached_to`
+  * `//joint/child`
+  * `//joint/parent`
+  * `//pose/@relative_to`
+  * `//xyz/@expressed_in`
+  * Additional Rules:
+    * If an attribute is either `"world"` or `"__model__"`, it will be
+    unchanged.
+    * If an attribute does *not* start with the given prefix, the conversion
+    will *fail fast*.
+
+Some notes:
+
+* Semantic validation will be handled by the parsing process itself, *not* by
+the naive up-conversion process.
+* This up-conversion is *only* intended to support models that *could* have
+been emitted by `libsdformat10` by using *valid* `//include` statements. It is possible to write valid models in SDFormat 1.7 that are invalid in SDFormat
+1.8; no effort will be made to reconcile those models (see examples below).
+* Since the naively converted file is neither SDFormat 1.5 nor 1.8, it is
+indicated as SDFormat `1.5*`, meaning that it's an intermediate format which
+namely adheres to SDFormat 1.5, but has directly nested models.
+* Since `libsdformat9.3` supported direct nesting but `//include` still
+worked via flattening, unflattening will occur regardless of whether or not
+there are directly nested models in the model, and the unflattening my handle
+"partially" flattened models.
+* No attempt will be made to "offset" the consituent elements' poses into
+the newly created `//model/pose`.
+  * This offers simplicity and ensures that the effective `__model__` frame
+  will coincide with the newly created nested models' `__model__` frames.
+
+**Example of a failing conversions**
+
+This could have been valid in SDFormat 1.7, but is not valid in SDFormat 1.8,
+even with up-coversion:
+~~~xml
+<sdf version="1.7">
+  <link name="M1::B"/>
+  <link name="M2::B">
+    <pose relative_to="M1::B"/>  <!-- INVALID: This attribute does not start with `M2::`. -->
+  </link>
+</sdf>
+~~~
 
 #### 1.5 Minimal `libsdformat` Interface Types for Non-SDFormat Models
 

--- a/composition/proposal.md
+++ b/composition/proposal.md
@@ -586,6 +586,9 @@ To illustrate, the following model from the
 ~~~xml
 <sdf version="1.4">
   <model name="ParentModel">
+    <frame name="ChildModel::__model__" attached_to="ChildModel::L1">
+      <pose/>
+    </frame>
     <link name="ChildModel::L1">
       <pose>1 1 1 0 0 0</pose>
       <visual name="v1">
@@ -672,10 +675,19 @@ namely adheres to SDFormat 1.5, but has directly nested models.
 worked via flattening, unflattening will occur regardless of whether or not
 there are directly nested models in the model, and the unflattening may handle
 "partially" flattened models.
-* No attempt will be made to "offset" the consituent elements' poses into
-the newly created `//model/pose`.
+* Nested models with an explicitly specified `__model__` frame (e.g.
+`ChildModel::__model__`) will have this frame removed, and this will be
+converted to the appropriate `//model/pose`
+(see [this BitBucket PR #668](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/668/page/1)
+for such an example). If `@attached_to` is specified to something other than
+this nexted model's first link, then `//model/@canonical_link` will also be
+updated.
+* If nested `__model__` frames are not present, no attempt will be made to
+implicitly "offset" the consituent elements' poses
+into the newly created `//model/pose`.
   * This offers simplicity and ensures that the effective `__model__` frame
   will coincide with the newly created nested models' `__model__` frames.
+  
 
 **Example of a failing conversions**
 

--- a/composition/proposal.md
+++ b/composition/proposal.md
@@ -80,8 +80,8 @@ For including models, it is nice to have access to other model types, e.g.
 including a custom model specified as a `*.yaml` or connecting to some other
 legacy format. Generally, the interface between models only really needs access
 to explicit and implicit frames (for welding joints, attaching sensors, etc.).
-The present implementation of `//include` (present
-[since `libsdformat4`](https://github.com/osrf/sdformat/blob/sdformat4_4.0.0/src/parser.cc#L738))
+The current implementation of `//include`
+([since `libsdformat4`](https://github.com/osrf/sdformat/blob/sdformat4_4.0.0/src/parser.cc#L738))
 requires that SDFormat know *everything* about the included model, whereas a
 user could instead provide an adapter to provide the minimal information
 necessary for assembly.
@@ -618,7 +618,9 @@ when a new model should be created and when the nested names (e.g.
 `M1::my_link`) should be "unnested" (e.g. `my_link` in model `M1`).
 
 To illustrate, the following model from the
-[Legacy Behavior](/tutorials?tut=composition&ver=1.5&#libsdformats-implementation-of-include-in-models) documentation will have been up-converted to the following in SDFormat 1.7 (as of `libsdformat` 9.2):
+[Legacy Behavior](/tutorials?tut=composition&ver=1.5&#libsdformats-implementation-of-include-in-models)
+documentation will have been up-converted to the following in SDFormat 1.7 (as
+of `libsdformat` 9.2):
 
 ~~~xml
 <sdf version="1.7">
@@ -721,6 +723,13 @@ something other than this nested model's first link, then
 * If nested `__model__` frames are not present, no attempt will be made to
 implicitly "offset" the consituent elements' poses
 into the newly created `//model/pose`.
+
+**Implementation**
+
+This will be implemented by modifying the implicit conversion schema
+(as defined and consumed by [`Converter.cc`](https://github.com/osrf/sdformat/blob/113bf26308f7354f446cc4dcd4746196d493bfde/src/Converter.cc))
+for the [currently blank SDFormat 1.7 -> 1.8 file](https://github.com/osrf/sdformat/blob/113bf26308f7354f446cc4dcd4746196d493bfde/sdf/1.8/1_7.convert) to
+have an element named `//unnest`, which will signify that the above mentioned changes should take place.
 
 **Example of a failing conversions**
 

--- a/composition/proposal.md
+++ b/composition/proposal.md
@@ -679,10 +679,12 @@ even with up-coversion:
 
 ~~~xml
 <sdf version="1.7">
-  <link name="M1::B"/>
-  <link name="M2::B">
-    <pose relative_to="M1::B"/>  <!-- INVALID: This attribute does not start with `M2::`. -->
-  </link>
+  <model name="anything">
+    <link name="M1::B"/>
+    <link name="M2::B">
+      <pose relative_to="M1::B"/>  <!-- INVALID: This attribute does not start with `M2::`. -->
+    </link>
+  </model>
 </sdf>
 ~~~
 

--- a/composition/proposal.md
+++ b/composition/proposal.md
@@ -58,10 +58,10 @@ swapping out grippers).
 As of SDFormat 1.7, nesting a model with a `//model/include` tag has different
 behavior than direct nesting with `//model/model`,
 part of the reason being that nesting directly with `//model/model` was not
-implemented in the `libsdformat` until 9.3.0. As mentioned in the
+implemented in `libsdformat` until 9.3.0. As mentioned in the
 [Legacy Behavior](/tutorials?tut=composition&ver=1.5&#libsdformats-implementation-of-include-in-models) documentation, `//include` works by effectively flattening the model; when this happens, certain details may "leak" through.
 
-Normall, nesting of models generally implies that the elements can be
+Normally, nesting of models generally implies that the elements can be
 referenced via a form of scope, such as `{scope}::{name}`.
 However, `::` is not a special token and thus can be
 used to create "false" hierarchy or potential name collisions. Additionally, there is
@@ -580,14 +580,15 @@ To work around this, the conversion from SDFormat 1.7 to 1.8 should have an
 when a new model should be created and when the nested names (e.g.
 `M1::my_link`) should be "unnested" (e.g. `my_link` in model `M1`).
 
-To illustrate, the following model from the Legacy Behavior documentation:
+To illustrate, the following model from the
+[Legacy Behavior](/tutorials?tut=composition&ver=1.5&#libsdformats-implementation-of-include-in-models) documentation:
 
 ~~~xml
-<sdf version="1.5">
+<sdf version="1.4">
   <model name="ParentModel">
     <link name="ChildModel::L1">
       <pose>1 1 1 0 0 0</pose>
-      <visual name="v1">-->
+      <visual name="v1">
         <geometry>
           <sphere>
             <radius>0.1</radius>
@@ -595,7 +596,9 @@ To illustrate, the following model from the Legacy Behavior documentation:
         </geometry>
       </visual>
     </link>
-    <link name="ChildModel::L2"/>
+    <link name="ChildModel::L2">
+      <pose>1 0 1 0 0 0</pose>
+    </link>
     <joint name="ChildModel::J1">
       <parent>ChildModel::L1</parent>
       <child>ChildModel::L2</child>
@@ -607,12 +610,12 @@ To illustrate, the following model from the Legacy Behavior documentation:
 should be (naively) up-converted to:
 
 ~~~xml
-<sdf version="1.5*">
+<sdf version="1.4*">
   <model name="ParentModel">
     <model name="ChildModel">
       <link name="L1">
         <pose>1 1 1 0 0 0</pose>
-        <visual name="v1">-->
+        <visual name="v1">
           <geometry>
             <sphere>
               <radius>0.1</radius>
@@ -620,7 +623,9 @@ should be (naively) up-converted to:
           </geometry>
         </visual>
       </link>
-      <link name="L2"/>
+      <link name="L2">
+        <pose>1 0 1 0 0 0</pose>
+      </link>
       <joint name="J1">
         <parent>L1</parent>
         <child>L2</child>
@@ -665,7 +670,7 @@ indicated as SDFormat `1.5*`, meaning that it's an intermediate format which
 namely adheres to SDFormat 1.5, but has directly nested models.
 * Since `libsdformat9.3` supported direct nesting but `//include` still
 worked via flattening, unflattening will occur regardless of whether or not
-there are directly nested models in the model, and the unflattening my handle
+there are directly nested models in the model, and the unflattening may handle
 "partially" flattened models.
 * No attempt will be made to "offset" the consituent elements' poses into
 the newly created `//model/pose`.


### PR DESCRIPTION
As motivated here: https://github.com/osrf/sdformat/pull/355#pullrequestreview-486246061
Towards osrf/sdformat#342
Resolves #39

Preview:
http://sdformat.org/tutorials?tut=composition_proposal&branch=feature-sdformat-pr355-up-convert&repo=https%3A%2F%2Fgithub.com%2FEricCousineau-TRI%2Fsdf_tutorials-1#1-4-7-up-converting-flattened-models

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/osrf/sdf_tutorials/41)
<!-- Reviewable:end -->
